### PR TITLE
Update Jaguar GPU to Rizin

### DIFF
--- a/jaguar-gpu/Makefile
+++ b/jaguar-gpu/Makefile
@@ -1,9 +1,9 @@
 NAME=jaguar-gpu
-R2_PLUGIN_PATH=$(shell r2 -hh|grep R2_LIBR_PLUGINS|awk '{print $$2}')
-CFLAGS=-g -fPIC $(shell pkg-config --cflags r_asm)
-LDFLAGS=-shared $(shell pkg-config --libs r_asm)
+RZ_PLUGIN_PATH=$(shell rizin -hh | grep RZ_LIBR_PLUGINS | awk '{print $$2}')
+CFLAGS=-g -fPIC $(shell pkg-config --cflags rz_asm)
+LDFLAGS=-shared $(shell pkg-config --libs rz_asm)
 OBJS=$(NAME).o
-SO_EXT=$(shell uname|grep -q Darwin && echo dylib || echo so)
+SO_EXT=$(shell uname | grep -q Darwin && echo dylib || echo so)
 LIB=$(NAME).$(SO_EXT)
 
 all: $(LIB)
@@ -15,7 +15,7 @@ $(LIB): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(LIB)
 
 install:
-	cp -f $(LIB) $(R2_PLUGIN_PATH)
+	cp -f $(LIB) $(RZ_PLUGIN_PATH)
 
 uninstall:
-	rm -f $(R2_PLUGIN_PATH)/$(LIB)
+	rm -f $(RZ_PLUGIN_PATH)/$(LIB)

--- a/jaguar-gpu/jaguar-gpu.c
+++ b/jaguar-gpu/jaguar-gpu.c
@@ -1,6 +1,6 @@
 /*
  * Disassembler for the Jaguar GPU/DSP
- * Copyright (C) 2018 - Sebastien Alaiwan
+ * SPDX-FileCopyrightText: 2018 Sebastien Alaiwan
  */
 
 #include <rz_asm.h>

--- a/jaguar-gpu/jaguar-gpu.c
+++ b/jaguar-gpu/jaguar-gpu.c
@@ -3,49 +3,62 @@
  * Copyright (C) 2018 - Sebastien Alaiwan
  */
 
-#include <r_asm.h>
-#include <r_lib.h>
+#include <rz_asm.h>
+#include <rz_lib.h>
 
-static int read16_BE (const ut8** b)
-{
+static int read16_BE(const ut8 **b) {
 	int val = ((*b)[0] << 8) | ((*b)[1] << 0);
 	(*b) += 2;
 	return val;
 }
 
-static const char* condition (int code)
-{
-	switch (code)
-	{
-	case 0:  return "mp"; /* always */
-	case 1:  return "nz";
-	case 2:  return "z";
-	case 4:  return "nc";
-	case 5:  return "nc/nz";
-	case 6:  return "nc/z";
-	case 8:  return "c";
-	case 9:  return "c/nz";
-	case 10: return "c/z";
-	case 20: return "nn";
-	case 21: return "nn/nz";
-	case 22: return "nn/z";
-	case 24: return "n";
-	case 25: return "n/nz";
-	case 26: return "n/z";
-	case 31: return "never";
-	default: return "?";
+static const char *condition(int code) {
+	switch (code) {
+	case 0:
+		return "mp"; /* always */
+	case 1:
+		return "nz";
+	case 2:
+		return "z";
+	case 4:
+		return "nc";
+	case 5:
+		return "nc/nz";
+	case 6:
+		return "nc/z";
+	case 8:
+		return "c";
+	case 9:
+		return "c/nz";
+	case 10:
+		return "c/z";
+	case 20:
+		return "nn";
+	case 21:
+		return "nn/nz";
+	case 22:
+		return "nn/z";
+	case 24:
+		return "n";
+	case 25:
+		return "n/nz";
+	case 26:
+		return "n/z";
+	case 31:
+		return "never";
+	default:
+		return "?";
 	}
 };
 
-static int notZero (int val)
-{
+static int notZero(int val) {
 	return val == 0 ? 32 : val;
 }
 
-static int disassemble (RAsm *a, RAsmOp *op, const ut8 *b, int l) {
-	const ut8* p = b; /* read pointer */
+static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+	const ut8 *p = buf; /* read pointer */
 
-	const uint word = read16_BE (&p);
+	const uint word = read16_BE(&p);
 	const uint opCode = (word >> 10) & 63;
 	const uint reg1 = (word >> 5) & 31;
 	const uint reg2 = (word >> 0) & 31;
@@ -53,158 +66,217 @@ static int disassemble (RAsm *a, RAsmOp *op, const ut8 *b, int l) {
 	uint pc = a->pc;
 
 	pc += 2;
-	switch (opCode)
-	{
-	case 0:  r_strbuf_setf (&op->buf_asm, "add     r%d, r%d", reg1, reg2);
-					 break;
-	case 1:  r_strbuf_setf (&op->buf_asm, "addc    r%d, r%d", reg1, reg2);
-					 break;
-	case 2:  r_strbuf_setf (&op->buf_asm, "addq    0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 3:  r_strbuf_setf (&op->buf_asm, "addqt   0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 4:  r_strbuf_setf (&op->buf_asm, "sub     r%d, r%d", reg1, reg2);
-					 break;
-	case 5:  r_strbuf_setf (&op->buf_asm, "subc    r%d, r%d", reg1, reg2);
-					 break;
-	case 6:  r_strbuf_setf (&op->buf_asm, "subq    0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 7:  r_strbuf_setf (&op->buf_asm, "subqt   0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 8:  r_strbuf_setf (&op->buf_asm, "neg     r%d", reg2);
-					 break;
-	case 9:  r_strbuf_setf (&op->buf_asm, "and     r%d, r%d", reg1, reg2);
-					 break;
-	case 10: r_strbuf_setf (&op->buf_asm, "or      r%d, r%d", reg1, reg2);
-					 break;
-	case 11: r_strbuf_setf (&op->buf_asm, "xor     r%d, r%d", reg1, reg2);
-					 break;
-	case 12: r_strbuf_setf (&op->buf_asm, "not     r%d", reg2);
-					 break;
-	case 13: r_strbuf_setf (&op->buf_asm, "btst    0x%x, r%d", reg1, reg2);
-					 break;
-	case 14: r_strbuf_setf (&op->buf_asm, "bset    0x%x, r%d", reg1, reg2);
-					 break;
-	case 15: r_strbuf_setf (&op->buf_asm, "bclr    0x%x, r%d", reg1, reg2);
-					 break;
-	case 16: r_strbuf_setf (&op->buf_asm, "mult    r%d, r%d", reg1, reg2);
-					 break;
-	case 17: r_strbuf_setf (&op->buf_asm, "imult   r%d, r%d", reg1, reg2);
-					 break;
-	case 18: r_strbuf_setf (&op->buf_asm, "imultn  r%d, r%d", reg1, reg2);
-					 break;
-	case 19: r_strbuf_setf (&op->buf_asm, "resmac  r%d", reg2);
-					 break;
-	case 20: r_strbuf_setf (&op->buf_asm, "imacn   r%d, r%d", reg1, reg2);
-					 break;
-	case 21: r_strbuf_setf (&op->buf_asm, "div     r%d, r%d", reg1, reg2);
-					 break;
-	case 22: r_strbuf_setf (&op->buf_asm, "abs     r%d", reg2);
-					 break;
-	case 23: r_strbuf_setf (&op->buf_asm, "sh      r%d, r%d", reg1, reg2);
-					 break;
-	case 24: r_strbuf_setf (&op->buf_asm, "shlq    0x%x, r%d", 32 - notZero (reg1), reg2);
-					 break;
-	case 25: r_strbuf_setf (&op->buf_asm, "shrq    0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 26: r_strbuf_setf (&op->buf_asm, "sha     r%d, r%d", reg1, reg2);
-					 break;
-	case 27: r_strbuf_setf (&op->buf_asm, "sharq   0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 28: r_strbuf_setf (&op->buf_asm, "ror     r%d, r%d", reg1, reg2);
-					 break;
-	case 29: r_strbuf_setf (&op->buf_asm, "rorq    0x%x, r%d", notZero (reg1), reg2);
-					 break;
-	case 30: r_strbuf_setf (&op->buf_asm, "cmp     r%d, r%d", reg1, reg2);
-					 break;
-	case 31: r_strbuf_setf (&op->buf_asm, "cmpq    0x%x, r%d", reg1, reg2);
-					 break;
-	case 32: r_strbuf_setf (&op->buf_asm, "sat8    r%d", reg2);
-					 break;
-	case 33: r_strbuf_setf (&op->buf_asm, "sat16   r%d", reg2);
-					 break;
-	case 34: r_strbuf_setf (&op->buf_asm, "move    r%d, r%d", reg1, reg2);
-					 break;
-	case 35: r_strbuf_setf (&op->buf_asm, "moveq   0x%x, r%d", reg1, reg2);
-					 break;
-	case 36: r_strbuf_setf (&op->buf_asm, "moveta  r%d, r%d", reg1, reg2);
-					 break;
-	case 37: r_strbuf_setf (&op->buf_asm, "movefa  r%d, r%d", reg1, reg2);
-					 break;
-	case 38:
-					 {
-						 uint low = read16_BE (&p);
-						 uint high = read16_BE (&p);
-						 r_strbuf_setf (&op->buf_asm, "movei   0x%x, r%d", low | (high << 16), reg2);
-						 break;
-					 }
-	case 39: r_strbuf_setf (&op->buf_asm, "loadb   [r%d], r%d", reg1, reg2);
-					 break;
-	case 40: r_strbuf_setf (&op->buf_asm, "loadw   [r%d], r%d", reg1, reg2);
-					 break;
-	case 41: r_strbuf_setf (&op->buf_asm, "load    [r%d], r%d", reg1, reg2);
-					 break;
-	case 42: r_strbuf_setf (&op->buf_asm, "loadp   [r%d], r%d", reg1, reg2);
-					 break;
-	case 43: r_strbuf_setf (&op->buf_asm, "load    [r14+0x%x], r%d", notZero (reg1)*4, reg2);
-					 break;
-	case 44: r_strbuf_setf (&op->buf_asm, "load    [r15+0x%x], r%d", notZero (reg1)*4, reg2);
-					 break;
-	case 45: r_strbuf_setf (&op->buf_asm, "storeb  r%d, [r%d]", reg2, reg1);
-					 break;
-	case 46: r_strbuf_setf (&op->buf_asm, "storew  r%d, [r%d]", reg2, reg1);
-					 break;
-	case 47: r_strbuf_setf (&op->buf_asm, "store   r%d, [r%d]", reg2, reg1);
-					 break;
-	case 48: r_strbuf_setf (&op->buf_asm, "storep  r%d, [r%d]", reg2, reg1);
-					 break;
-	case 49: r_strbuf_setf (&op->buf_asm, "store   r%d, [r14+0x%x]", reg2, notZero (reg1)*4);
-					 break;
-	case 50: r_strbuf_setf (&op->buf_asm, "store   r%d, [r15+0x%x]", reg2, notZero (reg1)*4);
-					 break;
-	case 51: r_strbuf_setf (&op->buf_asm, "move    pc, r%d", reg2);
-					 break;
-	case 52: r_strbuf_setf (&op->buf_asm, "j%s     [r%d]", condition(reg2), reg1);
-					 break;
-	case 53: r_strbuf_setf (&op->buf_asm, "j%s     0x%.8X", condition(reg2), pc + ((int8_t)(reg1 << 3) >> 2));
-					 break;
-	case 54: r_strbuf_setf (&op->buf_asm, "mmult   r%d, r%d", reg1, reg2);
-					 break;
-	case 55: r_strbuf_setf (&op->buf_asm, "mtoi    r%d, r%d", reg1, reg2);
-					 break;
-	case 56: r_strbuf_setf (&op->buf_asm, "normi   r%d, r%d", reg1, reg2);
-					 break;
-	case 57: r_strbuf_setf (&op->buf_asm, "nop");
-					 break;
-	case 58: r_strbuf_setf (&op->buf_asm, "load    [r14+r%d], r%d", reg1, reg2);
-					 break;
-	case 59: r_strbuf_setf (&op->buf_asm, "load    [r15+r%d], r%d", reg1, reg2);
-					 break;
-	case 60: r_strbuf_setf (&op->buf_asm, "store   r%d, [r14+r%d]", reg2, reg1);
-					 break;
-	case 61: r_strbuf_setf (&op->buf_asm, "store   r%d, [r15+r%d]", reg2, reg1);
-					 break;
-	case 62: r_strbuf_setf (&op->buf_asm, "sat24   r%d", reg2);
-					 break;
-	case 63:
-					 {
-						 if (reg1 == 0)
-							 r_strbuf_setf (&op->buf_asm, "pack    r%d", reg2);
-						 else if (reg1 == 1)
-							 r_strbuf_setf (&op->buf_asm, "unpack    r%d", reg2);
-						 else
-							 r_strbuf_setf (&op->buf_asm, "invalid");
-						 break;
-					 }
+	switch (opCode) {
+	case 0:
+		rz_strbuf_setf(&op->buf_asm, "add     r%d, r%d", reg1, reg2);
+		break;
+	case 1:
+		rz_strbuf_setf(&op->buf_asm, "addc    r%d, r%d", reg1, reg2);
+		break;
+	case 2:
+		rz_strbuf_setf(&op->buf_asm, "addq    0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 3:
+		rz_strbuf_setf(&op->buf_asm, "addqt   0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 4:
+		rz_strbuf_setf(&op->buf_asm, "sub     r%d, r%d", reg1, reg2);
+		break;
+	case 5:
+		rz_strbuf_setf(&op->buf_asm, "subc    r%d, r%d", reg1, reg2);
+		break;
+	case 6:
+		rz_strbuf_setf(&op->buf_asm, "subq    0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 7:
+		rz_strbuf_setf(&op->buf_asm, "subqt   0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 8:
+		rz_strbuf_setf(&op->buf_asm, "neg     r%d", reg2);
+		break;
+	case 9:
+		rz_strbuf_setf(&op->buf_asm, "and     r%d, r%d", reg1, reg2);
+		break;
+	case 10:
+		rz_strbuf_setf(&op->buf_asm, "or      r%d, r%d", reg1, reg2);
+		break;
+	case 11:
+		rz_strbuf_setf(&op->buf_asm, "xor     r%d, r%d", reg1, reg2);
+		break;
+	case 12:
+		rz_strbuf_setf(&op->buf_asm, "not     r%d", reg2);
+		break;
+	case 13:
+		rz_strbuf_setf(&op->buf_asm, "btst    0x%x, r%d", reg1, reg2);
+		break;
+	case 14:
+		rz_strbuf_setf(&op->buf_asm, "bset    0x%x, r%d", reg1, reg2);
+		break;
+	case 15:
+		rz_strbuf_setf(&op->buf_asm, "bclr    0x%x, r%d", reg1, reg2);
+		break;
+	case 16:
+		rz_strbuf_setf(&op->buf_asm, "mult    r%d, r%d", reg1, reg2);
+		break;
+	case 17:
+		rz_strbuf_setf(&op->buf_asm, "imult   r%d, r%d", reg1, reg2);
+		break;
+	case 18:
+		rz_strbuf_setf(&op->buf_asm, "imultn  r%d, r%d", reg1, reg2);
+		break;
+	case 19:
+		rz_strbuf_setf(&op->buf_asm, "resmac  r%d", reg2);
+		break;
+	case 20:
+		rz_strbuf_setf(&op->buf_asm, "imacn   r%d, r%d", reg1, reg2);
+		break;
+	case 21:
+		rz_strbuf_setf(&op->buf_asm, "div     r%d, r%d", reg1, reg2);
+		break;
+	case 22:
+		rz_strbuf_setf(&op->buf_asm, "abs     r%d", reg2);
+		break;
+	case 23:
+		rz_strbuf_setf(&op->buf_asm, "sh      r%d, r%d", reg1, reg2);
+		break;
+	case 24:
+		rz_strbuf_setf(&op->buf_asm, "shlq    0x%x, r%d", 32 - notZero(reg1), reg2);
+		break;
+	case 25:
+		rz_strbuf_setf(&op->buf_asm, "shrq    0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 26:
+		rz_strbuf_setf(&op->buf_asm, "sha     r%d, r%d", reg1, reg2);
+		break;
+	case 27:
+		rz_strbuf_setf(&op->buf_asm, "sharq   0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 28:
+		rz_strbuf_setf(&op->buf_asm, "ror     r%d, r%d", reg1, reg2);
+		break;
+	case 29:
+		rz_strbuf_setf(&op->buf_asm, "rorq    0x%x, r%d", notZero(reg1), reg2);
+		break;
+	case 30:
+		rz_strbuf_setf(&op->buf_asm, "cmp     r%d, r%d", reg1, reg2);
+		break;
+	case 31:
+		rz_strbuf_setf(&op->buf_asm, "cmpq    0x%x, r%d", reg1, reg2);
+		break;
+	case 32:
+		rz_strbuf_setf(&op->buf_asm, "sat8    r%d", reg2);
+		break;
+	case 33:
+		rz_strbuf_setf(&op->buf_asm, "sat16   r%d", reg2);
+		break;
+	case 34:
+		rz_strbuf_setf(&op->buf_asm, "move    r%d, r%d", reg1, reg2);
+		break;
+	case 35:
+		rz_strbuf_setf(&op->buf_asm, "moveq   0x%x, r%d", reg1, reg2);
+		break;
+	case 36:
+		rz_strbuf_setf(&op->buf_asm, "moveta  r%d, r%d", reg1, reg2);
+		break;
+	case 37:
+		rz_strbuf_setf(&op->buf_asm, "movefa  r%d, r%d", reg1, reg2);
+		break;
+	case 38: {
+		uint low = read16_BE(&p);
+		uint high = read16_BE(&p);
+		rz_strbuf_setf(&op->buf_asm, "movei   0x%x, r%d", low | (high << 16), reg2);
+		break;
+	}
+	case 39:
+		rz_strbuf_setf(&op->buf_asm, "loadb   [r%d], r%d", reg1, reg2);
+		break;
+	case 40:
+		rz_strbuf_setf(&op->buf_asm, "loadw   [r%d], r%d", reg1, reg2);
+		break;
+	case 41:
+		rz_strbuf_setf(&op->buf_asm, "load    [r%d], r%d", reg1, reg2);
+		break;
+	case 42:
+		rz_strbuf_setf(&op->buf_asm, "loadp   [r%d], r%d", reg1, reg2);
+		break;
+	case 43:
+		rz_strbuf_setf(&op->buf_asm, "load    [r14+0x%x], r%d", notZero(reg1) * 4, reg2);
+		break;
+	case 44:
+		rz_strbuf_setf(&op->buf_asm, "load    [r15+0x%x], r%d", notZero(reg1) * 4, reg2);
+		break;
+	case 45:
+		rz_strbuf_setf(&op->buf_asm, "storeb  r%d, [r%d]", reg2, reg1);
+		break;
+	case 46:
+		rz_strbuf_setf(&op->buf_asm, "storew  r%d, [r%d]", reg2, reg1);
+		break;
+	case 47:
+		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r%d]", reg2, reg1);
+		break;
+	case 48:
+		rz_strbuf_setf(&op->buf_asm, "storep  r%d, [r%d]", reg2, reg1);
+		break;
+	case 49:
+		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r14+0x%x]", reg2, notZero(reg1) * 4);
+		break;
+	case 50:
+		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r15+0x%x]", reg2, notZero(reg1) * 4);
+		break;
+	case 51:
+		rz_strbuf_setf(&op->buf_asm, "move    pc, r%d", reg2);
+		break;
+	case 52:
+		rz_strbuf_setf(&op->buf_asm, "j%s     [r%d]", condition(reg2), reg1);
+		break;
+	case 53:
+		rz_strbuf_setf(&op->buf_asm, "j%s     0x%.8X", condition(reg2), pc + ((int8_t)(reg1 << 3) >> 2));
+		break;
+	case 54:
+		rz_strbuf_setf(&op->buf_asm, "mmult   r%d, r%d", reg1, reg2);
+		break;
+	case 55:
+		rz_strbuf_setf(&op->buf_asm, "mtoi    r%d, r%d", reg1, reg2);
+		break;
+	case 56:
+		rz_strbuf_setf(&op->buf_asm, "normi   r%d, r%d", reg1, reg2);
+		break;
+	case 57:
+		rz_strbuf_setf(&op->buf_asm, "nop");
+		break;
+	case 58:
+		rz_strbuf_setf(&op->buf_asm, "load    [r14+r%d], r%d", reg1, reg2);
+		break;
+	case 59:
+		rz_strbuf_setf(&op->buf_asm, "load    [r15+r%d], r%d", reg1, reg2);
+		break;
+	case 60:
+		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r14+r%d]", reg2, reg1);
+		break;
+	case 61:
+		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r15+r%d]", reg2, reg1);
+		break;
+	case 62:
+		rz_strbuf_setf(&op->buf_asm, "sat24   r%d", reg2);
+		break;
+	case 63: {
+		if (reg1 == 0)
+			rz_strbuf_setf(&op->buf_asm, "pack    r%d", reg2);
+		else if (reg1 == 1)
+			rz_strbuf_setf(&op->buf_asm, "unpack    r%d", reg2);
+		else
+			rz_strbuf_setf(&op->buf_asm, "invalid");
+		break;
+	}
 	}
 
-	op->size = p - b;
-	r_strbuf_setbin (&op->buf_hex, b, op->size);
+	op->size = p - buf;
+	rz_strbuf_setbin(&op->buf, buf, op->size);
 
 	return op->size;
 }
 
-RAsmPlugin r_asm_plugin_jaguar_gpu = {
+RzAsmPlugin rz_asm_plugin_jaguar_gpu = {
 	.name = "jaguar-gpu",
 	.arch = "jaguar-gpu",
 	.author = "Sebastien Alaiwan",
@@ -215,8 +287,8 @@ RAsmPlugin r_asm_plugin_jaguar_gpu = {
 };
 
 #ifndef CORELIB
-RLibStruct radare_plugin = {
-	.type = R_LIB_TYPE_ASM,
-	.data = &r_asm_plugin_jaguar_gpu
+RzLibStruct rizin_plugin = {
+	.type = RZ_LIB_TYPE_ASM,
+	.data = &rz_asm_plugin_jaguar_gpu
 };
 #endif

--- a/jaguar-gpu/jaguar-gpu.c
+++ b/jaguar-gpu/jaguar-gpu.c
@@ -1,7 +1,7 @@
-/*
- * Disassembler for the Jaguar GPU/DSP
- * SPDX-FileCopyrightText: 2018 Sebastien Alaiwan
- */
+// SPDX-FileCopyrightText: 2018 Sebastien Alaiwan
+// SPDX-License-Identifier: LGPL-3.0-only
+
+//  Disassembler for the Jaguar GPU/DSP
 
 #include <rz_asm.h>
 #include <rz_lib.h>

--- a/jaguar-gpu/jaguar-gpu.c
+++ b/jaguar-gpu/jaguar-gpu.c
@@ -6,12 +6,6 @@
 #include <rz_asm.h>
 #include <rz_lib.h>
 
-static int read16_BE(const ut8 **b) {
-	int val = ((*b)[0] << 8) | ((*b)[1] << 0);
-	(*b) += 2;
-	return val;
-}
-
 #define asmprintf(fmt, ...) rz_strbuf_setf(&op->buf_asm, fmt, ##__VA_ARGS__)
 
 static const char *condition(int code) {
@@ -60,7 +54,8 @@ static int notZero(int val) {
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	const ut8 *p = buf; /* read pointer */
 
-	const uint word = read16_BE(&p);
+	const uint word = rz_read_be16(p);
+	p += 2;
 	const uint opCode = (word >> 10) & 63;
 	const uint reg1 = (word >> 5) & 31;
 	const uint reg2 = (word >> 0) & 31;
@@ -184,8 +179,8 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 		asmprintf("movefa  r%d, r%d", reg1, reg2);
 		break;
 	case 38: {
-		uint low = read16_BE(&p);
-		uint high = read16_BE(&p);
+		uint low = rz_read_be16(p);
+		uint high = rz_read_be16(p);
 		asmprintf("movei   0x%x, r%d", low | (high << 16), reg2);
 		break;
 	}

--- a/jaguar-gpu/jaguar-gpu.c
+++ b/jaguar-gpu/jaguar-gpu.c
@@ -12,6 +12,8 @@ static int read16_BE(const ut8 **b) {
 	return val;
 }
 
+#define asmprintf(fmt, ...) rz_strbuf_setf(&op->buf_asm, fmt, ##__VA_ARGS__)
+
 static const char *condition(int code) {
 	switch (code) {
 	case 0:
@@ -68,204 +70,204 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	pc += 2;
 	switch (opCode) {
 	case 0:
-		rz_strbuf_setf(&op->buf_asm, "add     r%d, r%d", reg1, reg2);
+		asmprintf("add     r%d, r%d", reg1, reg2);
 		break;
 	case 1:
-		rz_strbuf_setf(&op->buf_asm, "addc    r%d, r%d", reg1, reg2);
+		asmprintf("addc    r%d, r%d", reg1, reg2);
 		break;
 	case 2:
-		rz_strbuf_setf(&op->buf_asm, "addq    0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("addq    0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 3:
-		rz_strbuf_setf(&op->buf_asm, "addqt   0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("addqt   0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 4:
-		rz_strbuf_setf(&op->buf_asm, "sub     r%d, r%d", reg1, reg2);
+		asmprintf("sub     r%d, r%d", reg1, reg2);
 		break;
 	case 5:
-		rz_strbuf_setf(&op->buf_asm, "subc    r%d, r%d", reg1, reg2);
+		asmprintf("subc    r%d, r%d", reg1, reg2);
 		break;
 	case 6:
-		rz_strbuf_setf(&op->buf_asm, "subq    0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("subq    0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 7:
-		rz_strbuf_setf(&op->buf_asm, "subqt   0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("subqt   0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 8:
-		rz_strbuf_setf(&op->buf_asm, "neg     r%d", reg2);
+		asmprintf("neg     r%d", reg2);
 		break;
 	case 9:
-		rz_strbuf_setf(&op->buf_asm, "and     r%d, r%d", reg1, reg2);
+		asmprintf("and     r%d, r%d", reg1, reg2);
 		break;
 	case 10:
-		rz_strbuf_setf(&op->buf_asm, "or      r%d, r%d", reg1, reg2);
+		asmprintf("or      r%d, r%d", reg1, reg2);
 		break;
 	case 11:
-		rz_strbuf_setf(&op->buf_asm, "xor     r%d, r%d", reg1, reg2);
+		asmprintf("xor     r%d, r%d", reg1, reg2);
 		break;
 	case 12:
-		rz_strbuf_setf(&op->buf_asm, "not     r%d", reg2);
+		asmprintf("not     r%d", reg2);
 		break;
 	case 13:
-		rz_strbuf_setf(&op->buf_asm, "btst    0x%x, r%d", reg1, reg2);
+		asmprintf("btst    0x%x, r%d", reg1, reg2);
 		break;
 	case 14:
-		rz_strbuf_setf(&op->buf_asm, "bset    0x%x, r%d", reg1, reg2);
+		asmprintf("bset    0x%x, r%d", reg1, reg2);
 		break;
 	case 15:
-		rz_strbuf_setf(&op->buf_asm, "bclr    0x%x, r%d", reg1, reg2);
+		asmprintf("bclr    0x%x, r%d", reg1, reg2);
 		break;
 	case 16:
-		rz_strbuf_setf(&op->buf_asm, "mult    r%d, r%d", reg1, reg2);
+		asmprintf("mult    r%d, r%d", reg1, reg2);
 		break;
 	case 17:
-		rz_strbuf_setf(&op->buf_asm, "imult   r%d, r%d", reg1, reg2);
+		asmprintf("imult   r%d, r%d", reg1, reg2);
 		break;
 	case 18:
-		rz_strbuf_setf(&op->buf_asm, "imultn  r%d, r%d", reg1, reg2);
+		asmprintf("imultn  r%d, r%d", reg1, reg2);
 		break;
 	case 19:
-		rz_strbuf_setf(&op->buf_asm, "resmac  r%d", reg2);
+		asmprintf("resmac  r%d", reg2);
 		break;
 	case 20:
-		rz_strbuf_setf(&op->buf_asm, "imacn   r%d, r%d", reg1, reg2);
+		asmprintf("imacn   r%d, r%d", reg1, reg2);
 		break;
 	case 21:
-		rz_strbuf_setf(&op->buf_asm, "div     r%d, r%d", reg1, reg2);
+		asmprintf("div     r%d, r%d", reg1, reg2);
 		break;
 	case 22:
-		rz_strbuf_setf(&op->buf_asm, "abs     r%d", reg2);
+		asmprintf("abs     r%d", reg2);
 		break;
 	case 23:
-		rz_strbuf_setf(&op->buf_asm, "sh      r%d, r%d", reg1, reg2);
+		asmprintf("sh      r%d, r%d", reg1, reg2);
 		break;
 	case 24:
-		rz_strbuf_setf(&op->buf_asm, "shlq    0x%x, r%d", 32 - notZero(reg1), reg2);
+		asmprintf("shlq    0x%x, r%d", 32 - notZero(reg1), reg2);
 		break;
 	case 25:
-		rz_strbuf_setf(&op->buf_asm, "shrq    0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("shrq    0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 26:
-		rz_strbuf_setf(&op->buf_asm, "sha     r%d, r%d", reg1, reg2);
+		asmprintf("sha     r%d, r%d", reg1, reg2);
 		break;
 	case 27:
-		rz_strbuf_setf(&op->buf_asm, "sharq   0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("sharq   0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 28:
-		rz_strbuf_setf(&op->buf_asm, "ror     r%d, r%d", reg1, reg2);
+		asmprintf("ror     r%d, r%d", reg1, reg2);
 		break;
 	case 29:
-		rz_strbuf_setf(&op->buf_asm, "rorq    0x%x, r%d", notZero(reg1), reg2);
+		asmprintf("rorq    0x%x, r%d", notZero(reg1), reg2);
 		break;
 	case 30:
-		rz_strbuf_setf(&op->buf_asm, "cmp     r%d, r%d", reg1, reg2);
+		asmprintf("cmp     r%d, r%d", reg1, reg2);
 		break;
 	case 31:
-		rz_strbuf_setf(&op->buf_asm, "cmpq    0x%x, r%d", reg1, reg2);
+		asmprintf("cmpq    0x%x, r%d", reg1, reg2);
 		break;
 	case 32:
-		rz_strbuf_setf(&op->buf_asm, "sat8    r%d", reg2);
+		asmprintf("sat8    r%d", reg2);
 		break;
 	case 33:
-		rz_strbuf_setf(&op->buf_asm, "sat16   r%d", reg2);
+		asmprintf("sat16   r%d", reg2);
 		break;
 	case 34:
-		rz_strbuf_setf(&op->buf_asm, "move    r%d, r%d", reg1, reg2);
+		asmprintf("move    r%d, r%d", reg1, reg2);
 		break;
 	case 35:
-		rz_strbuf_setf(&op->buf_asm, "moveq   0x%x, r%d", reg1, reg2);
+		asmprintf("moveq   0x%x, r%d", reg1, reg2);
 		break;
 	case 36:
-		rz_strbuf_setf(&op->buf_asm, "moveta  r%d, r%d", reg1, reg2);
+		asmprintf("moveta  r%d, r%d", reg1, reg2);
 		break;
 	case 37:
-		rz_strbuf_setf(&op->buf_asm, "movefa  r%d, r%d", reg1, reg2);
+		asmprintf("movefa  r%d, r%d", reg1, reg2);
 		break;
 	case 38: {
 		uint low = read16_BE(&p);
 		uint high = read16_BE(&p);
-		rz_strbuf_setf(&op->buf_asm, "movei   0x%x, r%d", low | (high << 16), reg2);
+		asmprintf("movei   0x%x, r%d", low | (high << 16), reg2);
 		break;
 	}
 	case 39:
-		rz_strbuf_setf(&op->buf_asm, "loadb   [r%d], r%d", reg1, reg2);
+		asmprintf("loadb   [r%d], r%d", reg1, reg2);
 		break;
 	case 40:
-		rz_strbuf_setf(&op->buf_asm, "loadw   [r%d], r%d", reg1, reg2);
+		asmprintf("loadw   [r%d], r%d", reg1, reg2);
 		break;
 	case 41:
-		rz_strbuf_setf(&op->buf_asm, "load    [r%d], r%d", reg1, reg2);
+		asmprintf("load    [r%d], r%d", reg1, reg2);
 		break;
 	case 42:
-		rz_strbuf_setf(&op->buf_asm, "loadp   [r%d], r%d", reg1, reg2);
+		asmprintf("loadp   [r%d], r%d", reg1, reg2);
 		break;
 	case 43:
-		rz_strbuf_setf(&op->buf_asm, "load    [r14+0x%x], r%d", notZero(reg1) * 4, reg2);
+		asmprintf("load    [r14+0x%x], r%d", notZero(reg1) * 4, reg2);
 		break;
 	case 44:
-		rz_strbuf_setf(&op->buf_asm, "load    [r15+0x%x], r%d", notZero(reg1) * 4, reg2);
+		asmprintf("load    [r15+0x%x], r%d", notZero(reg1) * 4, reg2);
 		break;
 	case 45:
-		rz_strbuf_setf(&op->buf_asm, "storeb  r%d, [r%d]", reg2, reg1);
+		asmprintf("storeb  r%d, [r%d]", reg2, reg1);
 		break;
 	case 46:
-		rz_strbuf_setf(&op->buf_asm, "storew  r%d, [r%d]", reg2, reg1);
+		asmprintf("storew  r%d, [r%d]", reg2, reg1);
 		break;
 	case 47:
-		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r%d]", reg2, reg1);
+		asmprintf("store   r%d, [r%d]", reg2, reg1);
 		break;
 	case 48:
-		rz_strbuf_setf(&op->buf_asm, "storep  r%d, [r%d]", reg2, reg1);
+		asmprintf("storep  r%d, [r%d]", reg2, reg1);
 		break;
 	case 49:
-		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r14+0x%x]", reg2, notZero(reg1) * 4);
+		asmprintf("store   r%d, [r14+0x%x]", reg2, notZero(reg1) * 4);
 		break;
 	case 50:
-		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r15+0x%x]", reg2, notZero(reg1) * 4);
+		asmprintf("store   r%d, [r15+0x%x]", reg2, notZero(reg1) * 4);
 		break;
 	case 51:
-		rz_strbuf_setf(&op->buf_asm, "move    pc, r%d", reg2);
+		asmprintf("move    pc, r%d", reg2);
 		break;
 	case 52:
-		rz_strbuf_setf(&op->buf_asm, "j%s     [r%d]", condition(reg2), reg1);
+		asmprintf("j%s     [r%d]", condition(reg2), reg1);
 		break;
 	case 53:
-		rz_strbuf_setf(&op->buf_asm, "j%s     0x%.8X", condition(reg2), pc + ((int8_t)(reg1 << 3) >> 2));
+		asmprintf("j%s     0x%.8X", condition(reg2), pc + ((int8_t)(reg1 << 3) >> 2));
 		break;
 	case 54:
-		rz_strbuf_setf(&op->buf_asm, "mmult   r%d, r%d", reg1, reg2);
+		asmprintf("mmult   r%d, r%d", reg1, reg2);
 		break;
 	case 55:
-		rz_strbuf_setf(&op->buf_asm, "mtoi    r%d, r%d", reg1, reg2);
+		asmprintf("mtoi    r%d, r%d", reg1, reg2);
 		break;
 	case 56:
-		rz_strbuf_setf(&op->buf_asm, "normi   r%d, r%d", reg1, reg2);
+		asmprintf("normi   r%d, r%d", reg1, reg2);
 		break;
 	case 57:
-		rz_strbuf_setf(&op->buf_asm, "nop");
+		asmprintf("nop");
 		break;
 	case 58:
-		rz_strbuf_setf(&op->buf_asm, "load    [r14+r%d], r%d", reg1, reg2);
+		asmprintf("load    [r14+r%d], r%d", reg1, reg2);
 		break;
 	case 59:
-		rz_strbuf_setf(&op->buf_asm, "load    [r15+r%d], r%d", reg1, reg2);
+		asmprintf("load    [r15+r%d], r%d", reg1, reg2);
 		break;
 	case 60:
-		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r14+r%d]", reg2, reg1);
+		asmprintf("store   r%d, [r14+r%d]", reg2, reg1);
 		break;
 	case 61:
-		rz_strbuf_setf(&op->buf_asm, "store   r%d, [r15+r%d]", reg2, reg1);
+		asmprintf("store   r%d, [r15+r%d]", reg2, reg1);
 		break;
 	case 62:
-		rz_strbuf_setf(&op->buf_asm, "sat24   r%d", reg2);
+		asmprintf("sat24   r%d", reg2);
 		break;
 	case 63: {
 		if (reg1 == 0)
-			rz_strbuf_setf(&op->buf_asm, "pack    r%d", reg2);
+			asmprintf("pack    r%d", reg2);
 		else if (reg1 == 1)
-			rz_strbuf_setf(&op->buf_asm, "unpack    r%d", reg2);
+			asmprintf("unpack    r%d", reg2);
 		else
-			rz_strbuf_setf(&op->buf_asm, "invalid");
+			asmprintf("invalid");
 		break;
 	}
 	}

--- a/jaguar-gpu/meson.build
+++ b/jaguar-gpu/meson.build
@@ -1,6 +1,6 @@
 project('jaguar-gpu', 'c')
 
-plugins_dir = join_paths(get_option('prefix'), 'lib', 'rizin', '0.2.0-git')
+plugins_dir = join_paths(get_option('prefix'), 'share', 'rizin', 'plugins')
 
 rz_asm_lib = dependency('rz_asm')
 

--- a/jaguar-gpu/meson.build
+++ b/jaguar-gpu/meson.build
@@ -1,0 +1,12 @@
+project('jaguar-gpu', 'c')
+
+plugins_dir = join_paths(get_option('prefix'), 'lib', 'rizin', '0.2.0-git')
+
+rz_asm_lib = dependency('rz_asm')
+
+library('jaguar-gpu',
+  ['jaguar-gpu.c'],
+  dependencies: [rz_asm_lib],
+  install: true,
+  install_dir: plugins_dir,
+) 


### PR DESCRIPTION
Update Jaguar GPU to Rizin. 
Just renamed the r2 data structures to its Rizin equivalent, preserving the logic, in an effort to learn about plugins.

It builds and gets installed. Haven't really tested it, yet.
```
$ make
cc -g -fPIC -I/usr/local/include/librz -I/usr/local/include/librz/sdb    -c -o jaguar-gpu.o jaguar-gpu.c
cc -g -fPIC -I/usr/local/include/librz -I/usr/local/include/librz/sdb  -shared -L/usr/local/lib -lrz_asm -lrz_parse -lrz_cons -lrz_reg -lrz_flag -lrz_bin -lrz_magic -lrz_io -lrz_syscall -lrz_socket -lrz_util  jaguar-gpu.o -o jaguar-gpu.so

$ rz-asm -L | grep -i jag
_d__  32         jaguar-gpu  LGPL3   Disassembler for the Jaguar GPU (by Sebastien Alaiwan)
```